### PR TITLE
Print errors to stderr, and signal errors with non-zero exit code

### DIFF
--- a/ward/addguards2.lua
+++ b/ward/addguards2.lua
@@ -22,8 +22,9 @@ if string.sub(file, -2, -1) == ".c" then
     io.flush()
     os.execute(ward .. "/bin/addguards " .. guard .. " " .. file)
   else
-    io.write("/* ERROR: Ward failed to parse C source */\n")
-    catfile(file)
+    io.stderr:write("ERROR: Ward failed to parse C source\n")
+    os.remove(guard)
+    os.exit(1)
   end
   os.remove(guard)
 else

--- a/ward/cparser.lua
+++ b/ward/cparser.lua
@@ -1344,10 +1344,10 @@ function show_error(input, mapping, pos, message)
   local sourcefile, sourceline, sourcecol, line =
     find_source_position(input, pos, mapping)
   if message then
-    io.stderr:write(string.format("%s:%d,%d:%s\n", sourcefile, sourceline, sourcecol,
+    io.stderr:write(string.format("%s:%d:%d: %s\n", sourcefile, sourceline, sourcecol,
       message))
   else
-    io.stderr:write(string.format("%s:%d,%d\n", sourcefile, sourceline, sourcecol))
+    io.stderr:write(string.format("%s:%d:%d\n", sourcefile, sourceline, sourcecol))
   end
   if options.verbose then
     line = string.gsub(line, "[\r\n]", "")

--- a/ward/cparser.lua
+++ b/ward/cparser.lua
@@ -1344,15 +1344,15 @@ function show_error(input, mapping, pos, message)
   local sourcefile, sourceline, sourcecol, line =
     find_source_position(input, pos, mapping)
   if message then
-    print(string.format("%s:%d,%d:%s", sourcefile, sourceline, sourcecol,
+    io.stderr:write(string.format("%s:%d,%d:%s\n", sourcefile, sourceline, sourcecol,
       message))
   else
-    print(string.format("%s:%d,%d", sourcefile, sourceline, sourcecol))
+    io.stderr:write(string.format("%s:%d,%d\n", sourcefile, sourceline, sourcecol))
   end
   if options.verbose then
     line = string.gsub(line, "[\r\n]", "")
-    print(line)
-    print(string.rep(" ", sourcecol-1).."^")
+    io.stderr:write(line .. "\n")
+    io.stderr:write(string.rep(" ", sourcecol-1).."^" .. "\n")
   end
 end
 

--- a/ward/util.lua
+++ b/ward/util.lua
@@ -63,12 +63,12 @@ push = table.insert
 pop = table.remove
 
 function fatal_error(pos, message)
-  print(message)
+  io.stderr:write(message .. "\n")
   os.exit(1)
 end
 
 function system_error(message)
-  print(message)
+  io.stderr:write(message .. "\n")
   os.exit(1)
 end
 


### PR DESCRIPTION
These changes are required for the new build system in the `hpc-merge` branch at https://github.com/fingolfin/gap

I'd argue they are correct for the old HPC-GAP build system, too.