### PR TITLE
Support -cc option.

### DIFF
--- a/ward/addguards2.lua
+++ b/ward/addguards2.lua
@@ -1,3 +1,5 @@
+require "util"
+
 function catfile(file)
   local fp = io.open(file)
   local contents = fp:read("*a")
@@ -6,7 +8,7 @@ function catfile(file)
 end
 
 ward = os.getenv("WARD")
-args = table.concat({...}, " ")
+args = table.concat(map({...}, shell_escape), " ")
 argtable = {...}
 file = argtable[#argtable]
 if string.sub(file, -2, -1) == ".c" then

--- a/ward/addguards2c.lua
+++ b/ward/addguards2c.lua
@@ -1,3 +1,5 @@
+require "util"
+
 function catfile(file)
   local fp = io.open(file)
   local contents = fp:read("*a")
@@ -6,12 +8,20 @@ function catfile(file)
 end
 
 ward = os.getenv("WARD")
-args = table.concat({...}, " ")
+args = table.concat(map({...}, shell_escape), " ")
 argtable = {...}
 file = argtable[#argtable]
 if string.sub(file, -2, -1) == ".c" then
   guard = os.tmpname()
   if os.execute(ward .. "/bin/cward -suggest " .. args .. ">" .. guard) == 0 then
+    io.write("/***********************************************************/\n")
+    io.write("/*                                                         */\n")
+    io.write("/*       NOTE: This file was preprocessed by Ward.         */\n")
+    io.write("/*       Do not edit it; changes will be lost.             */\n")
+    io.write("/*                                                         */\n")
+    io.write("/***********************************************************/\n")
+    io.write("\n")
+    io.flush()
     os.execute(ward .. "/bin/addguardsc " .. guard .. " " .. file)
   else
     io.write("/* ERROR: Ward failed to parse C source */\n")

--- a/ward/cparser.lua
+++ b/ward/cparser.lua
@@ -138,7 +138,7 @@ local keywords = {
   'int', 'switch', 'double', 'long', 'typedef', 'else', 'register',
   'union', '__asm', '__asm__', '__thread', '__builtin_va_list', '__inline__',
   '__builtin_va_arg', '__extension__', '__const', '__restrict', '__volatile__',
-  '__signed', '__unsigned', '_Alignof',
+  '__signed', '__unsigned', '_Alignof', '_Nonnull',
 }
 
 local is_keyword = { }
@@ -804,23 +804,27 @@ local grammar = pattern {
     keyword "__extension__" * sp * rule "record_member",
   type_spec = action(rule "type_prefix" * sp * rule "type_declaration",
     build_typed_declaration),
-  type_prefix = rule "const_or_volatile" * rule "basetype",
-  const_or_volatile_prefix = (keyword "const" * sp + keyword "volatile" * sp
-    + keyword "__const" * sp),
-  const_or_volatile = (rule "const_or_volatile_prefix")^0,
+  type_prefix = rule "type_access_qualifier" * rule "basetype",
+  type_access_qualifier_prefix = (
+    keyword "const" * sp +
+    keyword "volatile" * sp +
+    keyword "__const" * sp +
+    keyword "_Nonnull" * sp
+  ),
+  type_access_qualifier = (rule "type_access_qualifier_prefix")^0,
   restrict = (keyword "restrict" + keyword "__restrict"),
   type_declaration =
     action(pattern "(" * sp * rule "type_declaration" * sp * pattern ")" *
       rule "type_postfix", build_type_postfix) +
-    action(rule "const_or_volatile" * sp * (pattern "*" + pattern "^") * sp *
-           rule "type_declaration",
+    action(rule "type_access_qualifier" * sp *
+           (pattern "*" + pattern "^") * sp * rule "type_declaration",
       function(s, p, c)
         push(c, "*")
 	return p, c
       end) +
     action((rule "restrict" * sp)^-1 * aggregate(pos_ident_or_type) *
       rule "type_postfix", build_type_postfix)+
-    action(rule "const_or_volatile_prefix" * rule "type_declaration",
+    action(rule "type_access_qualifier_prefix" * rule "type_declaration",
       function(s, p, c)
         return p, c
       end)+
@@ -1165,7 +1169,7 @@ local grammar = pattern {
     rule "opt_asm_declaration" * (sp * attributes)^-1 * sp * pattern ";",
   function_definition =
     action(rule "storage_classifiers" *
-      rule "const_or_volatile" * rule "basetype" *
+      rule "type_access_qualifier" * rule "basetype" *
       aggregate((sp * capture(pattern "*"))^0) * sp *
       (attributes * sp)^-1 * ident * sp *
       rule "function_arguments" * sp * rule "compound_statement" *

--- a/ward/ward.lua
+++ b/ward/ward.lua
@@ -16,6 +16,8 @@ options = {
   debug = false,
 }
 
+local ccprog = "cc"
+
 local i = 1
 while i <= #arg do
   local argument = arg[i]
@@ -45,6 +47,9 @@ while i <= #arg do
        system_error "The -I option requires a directory argument"
       end
       push(preprocessor_options, "-I"..incdir)
+    elseif argument == "-cc" then
+      ccprog = arg[i]
+      i = i + 1
     elseif string.sub(argument, 1, 2) == "-I" then
       push(preprocessor_options, argument)
     elseif string.sub(argument, 1, 2) == "-D" then
@@ -65,7 +70,7 @@ while i <= #arg do
       system_error("Unknown option '" .. argument .. "'")
     end
   else
-    local command = {"gcc", "-E"}
+    local command = { ccprog, "-E" }
     for _, opt in ipairs(preprocessor_options) do
       push(command, opt)
     end


### PR DESCRIPTION
Support a -cc option to specify a C compiler. This can also be passed through the addguards2/addguards2c commands.

This PR also includes _Nonnull support from the previous PR.