### PR TITLE
Support for C11 and Objective-C features.

### DIFF
--- a/ward/config.lua
+++ b/ward/config.lua
@@ -24,7 +24,6 @@ preprocessor_options = {
   "-D__extension__=",
   "-D__attribute__(x)=",
   -- Ignore C11 annotations.
-  "-D_Noreturn=",
   "-D_Alignas(x)=",
   -- TODO: The following is a workaround around __typeof() occurring
   -- in Linux header files. The correct solution is to properly deal


### PR DESCRIPTION
MacOS header files may require support for nullability annotations. Also,
some explicit support for C11 features.