### PR TITLE
Add _Float128 floating point type

### DIFF
--- a/ward/cparser.lua
+++ b/ward/cparser.lua
@@ -748,6 +748,7 @@ local grammar = pattern {
   basetype =
     keyword "void" * value(new(TypeVoid)) +
     rule "float_type" +
+    rule "iso_ext_float_type" +
     rule "integral_type" +
     keyword "unsigned" * value(type_int) +
     keyword "signed" * value(type_int) +
@@ -766,6 +767,12 @@ local grammar = pattern {
     keyword "float" * value(type_float) +
     keyword "double" * value(type_float) +
     keyword "long" * sp * rule "float_type",
+  iso_ext_float_type =
+    -- ISO/IEC TS 18661-3:2015 defines C support for additional
+    -- floating types _Floatn and _Floatnx,
+    keyword "_Float32" * value(type_float) +
+    keyword "_Float64" * value(type_float) +
+    keyword "_Float128" * value(type_float),
   integral_type = 
     keyword "int" * value(type_int) +
     keyword "short" * sp * rule "integral_type" +


### PR DESCRIPTION
This is introduced at least in GCC 7.0 upwards and breaks ward on at least some of our department machines.

Reference: https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html